### PR TITLE
ci(renovate): configure renovate for k8s, docker, and helm

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,29 @@
+{
+  extends: ["config:base"],
+  kubernetes: {
+    fileMatch: ["cluster/.+\\.ya?ml$"],
+    ignorePaths: ["cluster/flux-system/"],
+  },
+  regexManagers: [
+    // regexManager to read and process HelmRelease files
+    {
+      fileMatch: ["cluster/.+\\.ya?ml$"],
+      matchStrings: [
+        // helm releases
+        "registryUrl=(?<registryUrl>.*?)\n *chart: (?<depName>.*?)\n *version: (?<currentValue>.*)\n",
+      ],
+      datasourceTemplate: "helm",
+    },
+  ],
+  packageRules: [
+    // add labels according to package
+    {
+      matchDatasources: ["docker"],
+      labels: ["renovate/image"],
+    },
+    {
+      matchDatasources: ["helm"],
+      labels: ["renovate/helm"],
+    },
+  ],
+}

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -76,3 +76,24 @@ branches:
       required_linear_history: null
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
       restrictions: null
+
+# Labels: define labels for Issues and Pull Requests
+labels:
+  - name: bug
+    color: d73a4a
+    description: Something isn't working 🐛.
+  - name: documentation
+    color: 0075ca
+    description: Improvements or additions to documentation 📚
+  - name: enhancement
+    color: a2eeef
+    description: New feature ✨
+  - name: flux/update
+    color: e4e669
+    description: Automated flux version update ⬆️
+  - name: renovate/image
+    color: 7057ff
+    description: Automated image version update ⬆️
+  - name: renovate/helm
+    color: 008672
+    description: Automated chart version update ⬆️

--- a/.github/workflows/update-flux.yaml
+++ b/.github/workflows/update-flux.yaml
@@ -34,3 +34,4 @@ jobs:
           title: "chore(deps): update flux components to ${{ steps.update.outputs.flux_version }}"
           body: |
             Release notes: https://github.com/fluxcd/flux2/releases/tag/${{ steps.update.outputs.flux_version }}
+          labels: flux/update


### PR DESCRIPTION
Add configuration for renovate to automatically update docker, helm, and kubernetes versions.
Additionally add labels to the GitHub repo for grouping PRs.