### PR TITLE
fix(settings): remove emoji from label descriptions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -81,19 +81,19 @@ branches:
 labels:
   - name: bug
     color: d73a4a
-    description: Something isn't working 🐛.
+    description: Something isn't working
   - name: documentation
     color: 0075ca
-    description: Improvements or additions to documentation 📚
+    description: Improvements or additions to documentation
   - name: enhancement
     color: a2eeef
-    description: New feature ✨
+    description: New feature
   - name: flux/update
     color: e4e669
-    description: Automated flux version update ⬆️
+    description: Automated flux version update
   - name: renovate/image
     color: 7057ff
-    description: Automated image version update ⬆️
+    description: Automated image version update
   - name: renovate/helm
     color: 008672
-    description: Automated chart version update ⬆️
+    description: Automated chart version update


### PR DESCRIPTION
GitHub will not create labels with descriptions containing unicode characters above 0xffff which
includes many emojis.